### PR TITLE
Add support for data URLs with empty mimetypes, like `data:,abc`.

### DIFF
--- a/data_url/__init__.py
+++ b/data_url/__init__.py
@@ -2,7 +2,7 @@ import re
 import base64
 
 DATA_URL_RE = re.compile(
-    r"data:(?P<MIME>[\w-]+\/[\w+-]+(;[\w-]+\=[\w-]+)?)(?P<encoded>;base64)?,(?P<data>[\w\d.~%\=\/\+-]+)"
+    r"data:(?P<MIME>([\w-]+\/[\w+-]+(;[\w-]+\=[\w-]+)?)?)(?P<encoded>;base64)?,(?P<data>[\w\d.~%\=\/\+-]+)"
 )
 
 def construct_data_url(mime_type, base64_encoded, data):

--- a/test/test_url.py
+++ b/test/test_url.py
@@ -18,6 +18,19 @@ class TestUrlCreation(unittest.TestCase):
         self.assertEqual(base64_encoded, deconstructed_url.is_base64_encoded)
         self.assertEqual(data, deconstructed_url.data)
 
+    def test_construct_data_url_without_mime_type(self):
+        mime_type = ""
+        base64_encoded = False
+        data = str(uuid.uuid4()).strip()
+        url = construct_data_url(mime_type, base64_encoded, data)
+
+        deconstructed_url = DataURL.from_url(url)
+
+        self.assertEqual(mime_type, deconstructed_url.mime_type)
+        self.assertEqual(base64_encoded, deconstructed_url.is_base64_encoded)
+        self.assertEqual(data, deconstructed_url.data)
+        self.assertEqual(url, f"data:,{data}")
+
     def test_construct_data_url(self):
         mime_type = "text/plain"
         base64_encoded = False
@@ -62,6 +75,16 @@ class TestFromData(unittest.TestCase):
 
         self.url = DataURL.from_data(self.mime_type, self.base64_encoded, self.data)
         self.assertEqual(type(self.url.data), bytes)
+        self.run_assertions()
+
+    def test_string_with_empty_mimetype(self):
+        self.mime_type = ""
+        self.base64_encoded = False
+        self.data = str(uuid.uuid4())
+        self.raw_data = self.data
+        self.expected_url = f"data:,{self.data}"
+        self.url = DataURL.from_data(self.mime_type, self.base64_encoded, self.data)
+        self.assertEqual(type(self.url.data), str)
         self.run_assertions()
 
     def run_assertions(self):


### PR DESCRIPTION
Per the data URL spec, the mimetype segment of a data URL should be optional. 

The change here, which might be hard to read in a diff, is adding an extra pair of parentheses and question mark to the regular expression to make the mimetype optional.

I've also added a test that fails without the change and verifies that we can construct and render a URL without a specified mimetype.