### PR TITLE
Updated regex and url parsing

### DIFF
--- a/data_url/__init__.py
+++ b/data_url/__init__.py
@@ -4,7 +4,7 @@ import base64
 DATA_URL_RE = re.compile(
     r"""
     data:                                         # literal data:
-    (?P<MIME>[\w\-\.+]+/[\w\-\.+]+)?              # optional media type
+    (?P<MIME>[a-z][a-z0-9\-]+/[a-z][\w\-\.\+]+)?  # optional media type
     (?P<parameters>(?:;[\w\-\.+]+=[\w\-\.+%]+)*)  # optional attribute=values, value can be url encoded
     (?P<encoded>;base64)?,                        # optional base64 flag
     (?P<data>[\w\d.~%\=\/\+-]+)                   # the data
@@ -115,7 +115,7 @@ class DataURL:
     def __parse_url(self):
         """Parses a data URL to get each individual element and sets the
         respecting class attributes."""
-        match = DATA_URL_RE.search(self._url)
+        match = DATA_URL_RE.fullmatch(self._url)
         if match:
             self._is_base64_encoded = match.group('encoded') is not None
             self._mime_type = match.group("MIME") or ""

--- a/test/test_url.py
+++ b/test/test_url.py
@@ -60,6 +60,10 @@ class TestUrlCreation(unittest.TestCase):
         self.assertEqual(raw_data, deconstructed_url.data)
         self.assertEqual(data, deconstructed_url.encoded_data)
 
+    def test_non_compliant_url(self):
+        url = DataURL.from_url("not a url")
+        assert url is None
+
 class TestFromData(unittest.TestCase):
     def test_typing(self):
         with self.assertRaises(Exception) as context:


### PR DESCRIPTION
## ✨ Changes

The data url regex is made verbose so it is easier to read. It also contains a capture for parameters (_attribute=value_). In a follow up PR I'll add the ability to parse and assemble parameters.

Using re.search instead of re.fullmatch allows for urls embedded within text. A follow up could potentially iterate through found urls.

I also check to see if the regex actually did match if not, `DataURL.from_url` returns `None` to indicate no match.